### PR TITLE
AWS-CF Templates for Roles and Beanstalk

### DIFF
--- a/CF-templates/beanstalk.yaml
+++ b/CF-templates/beanstalk.yaml
@@ -26,14 +26,6 @@ Parameters:
         Type: AWS::EC2::Subnet::Id
         Description: Public subnet for EB instance (default VPC subnet)
 
-    ServiceRoleArn:
-        Type: String
-        Description: Elastic Beanstalk Service Role ARN
-
-    InstanceProfileName:
-        Type: String
-        Description: EC2 Instance Profile name for EB instances
-
 Resources:
     # --------------------------------------------------------------------
     # Elastic Beanstalk Application
@@ -64,7 +56,7 @@ Resources:
 
                 - Namespace: aws:elasticbeanstalk:environment
                   OptionName: ServiceRole
-                  Value: !Ref ServiceRoleArn
+                  Value: !ImportValue SoitinStock-ServiceRoleArn
 
                 # -------------------------
                 # EC2 Instance Configuration
@@ -75,7 +67,7 @@ Resources:
 
                 - Namespace: aws:autoscaling:launchconfiguration
                   OptionName: IamInstanceProfile
-                  Value: !Ref InstanceProfileName
+                  Value: !ImportValue SoitinStock-InstanceProfileName
 
                 - Namespace: aws:autoscaling:launchconfiguration
                   OptionName: EC2KeyName

--- a/CF-templates/beanstalk.yaml
+++ b/CF-templates/beanstalk.yaml
@@ -1,0 +1,196 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'SoitinStock - Elastic Beanstalk Layer 1 (Environment Foundation)'
+
+Parameters:
+    ApplicationName:
+        Type: String
+        Default: SoitinStock
+
+    EnvironmentName:
+        Type: String
+        Default: SoitinStock-env
+
+    InstanceType:
+        Type: String
+        Default: t4g.small
+
+    KeyPairName:
+        Type: String
+        Default: vockey
+
+    VPCId:
+        Type: AWS::EC2::VPC::Id
+        Description: Default VPC is fine for now
+
+    SubnetId:
+        Type: AWS::EC2::Subnet::Id
+        Description: Public subnet for EB instance (default VPC subnet)
+
+    ServiceRoleArn:
+        Type: String
+        Description: Elastic Beanstalk Service Role ARN
+
+    InstanceProfileName:
+        Type: String
+        Description: EC2 Instance Profile name for EB instances
+
+Resources:
+    # --------------------------------------------------------------------
+    # Elastic Beanstalk Application
+    # --------------------------------------------------------------------
+    EBApplication:
+        Type: AWS::ElasticBeanstalk::Application
+        Properties:
+            ApplicationName: !Ref ApplicationName
+
+    # --------------------------------------------------------------------
+    # Elastic Beanstalk Environment
+    # --------------------------------------------------------------------
+    EBEnvironment:
+        Type: AWS::ElasticBeanstalk::Environment
+        Properties:
+            ApplicationName: !Ref EBApplication
+            EnvironmentName: !Ref EnvironmentName
+
+            SolutionStackName: '64bit Amazon Linux 2023 v6.10.1 running Node.js 24'
+
+            OptionSettings:
+                # -------------------------
+                # Environment Type
+                # -------------------------
+                - Namespace: aws:elasticbeanstalk:environment
+                  OptionName: EnvironmentType
+                  Value: SingleInstance
+
+                - Namespace: aws:elasticbeanstalk:environment
+                  OptionName: ServiceRole
+                  Value: !Ref ServiceRoleArn
+
+                # -------------------------
+                # EC2 Instance Configuration
+                # -------------------------
+                - Namespace: aws:autoscaling:launchconfiguration
+                  OptionName: InstanceType
+                  Value: !Ref InstanceType
+
+                - Namespace: aws:autoscaling:launchconfiguration
+                  OptionName: IamInstanceProfile
+                  Value: !Ref InstanceProfileName
+
+                - Namespace: aws:autoscaling:launchconfiguration
+                  OptionName: EC2KeyName
+                  Value: !Ref KeyPairName
+
+                - Namespace: aws:autoscaling:launchconfiguration
+                  OptionName: DisableIMDSv1
+                  Value: 'true'
+
+                # SSH access disabled (no direct EC2 access required)
+                # Logs and debugging handled via Elastic Beanstalk / CloudWatch
+                # ⚠️ SECURITY FIX (was previously open in your setup)
+                # - Namespace: aws:autoscaling:launchconfiguration
+                #   OptionName: SSHSourceRestriction
+                #   Value: 'tcp,22,22,0.0.0.0/0' # TODO: restrict later or disable SSH entirely
+
+                # -------------------------
+                # Capacity (Single instance)
+                # -------------------------
+                - Namespace: aws:autoscaling:asg
+                  OptionName: MinSize
+                  Value: '1'
+
+                - Namespace: aws:autoscaling:asg
+                  OptionName: MaxSize
+                  Value: '1'
+
+                # -------------------------
+                # VPC Configuration (Default VPC)
+                # -------------------------
+                - Namespace: aws:ec2:vpc
+                  OptionName: VPCId
+                  Value: !Ref VPCId
+
+                - Namespace: aws:ec2:vpc
+                  OptionName: Subnets
+                  Value: !Ref SubnetId
+
+                - Namespace: aws:ec2:vpc
+                  OptionName: ELBSubnets
+                  Value: !Ref SubnetId
+
+                - Namespace: aws:ec2:vpc
+                  OptionName: ELBScheme
+                  Value: public
+
+                - Namespace: aws:ec2:vpc
+                  OptionName: AssociatePublicIpAddress
+                  Value: 'true'
+
+                # -------------------------
+                # Node.js / Proxy
+                # -------------------------
+                - Namespace: aws:elasticbeanstalk:environment:proxy
+                  OptionName: ProxyServer
+                  Value: nginx
+
+                # -------------------------
+                # Monitoring (basic dev-safe setup)
+                # -------------------------
+                - Namespace: aws:elasticbeanstalk:cloudwatch:logs
+                  OptionName: StreamLogs
+                  Value: 'true'
+
+                - Namespace: aws:elasticbeanstalk:cloudwatch:logs
+                  OptionName: RetentionInDays
+                  Value: '7'
+
+                # -------------------------
+                # Deployment strategy (safe default)
+                # -------------------------
+                - Namespace: aws:elasticbeanstalk:command
+                  OptionName: DeploymentPolicy
+                  Value: AllAtOnce
+
+                - Namespace: aws:elasticbeanstalk:command
+                  OptionName: Timeout
+                  Value: '600'
+
+                # -------------------------
+                # PLACEHOLDER: Environment variables (future Cognito + RDS)
+                # -------------------------
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: NODE_ENV
+                  Value: development
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: COGNITO_USER_POOL_ID
+                  Value: ''
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: COGNITO_CLIENT_ID
+                  Value: ''
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: RDS_HOST
+                  Value: ''
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: RDS_PORT
+                  Value: ''
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: RDS_DB_NAME
+                  Value: ''
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: RDS_USERNAME
+                  Value: ''
+
+                - Namespace: aws:elasticbeanstalk:application:environment
+                  OptionName: RDS_PASSWORD
+                  Value: ''
+
+Outputs:
+    EnvironmentURL:
+        Description: 'Elastic Beanstalk environment URL'
+        Value: !GetAtt EBEnvironment.EndpointURL

--- a/CF-templates/beanstalk.yaml
+++ b/CF-templates/beanstalk.yaml
@@ -77,6 +77,9 @@ Resources:
                   OptionName: DisableIMDSv1
                   Value: 'true'
 
+                # -------------------------
+                # SSH Configuration
+                # -------------------------
                 # SSH access disabled (no direct EC2 access required)
                 # Logs and debugging handled via Elastic Beanstalk / CloudWatch
                 # ⚠️ SECURITY FIX (was previously open in your setup)
@@ -148,7 +151,7 @@ Resources:
                   Value: '600'
 
                 # -------------------------
-                # PLACEHOLDER: Environment variables (future Cognito + RDS)
+                # PLACEHOLDERS: Environment variables (future Cognito + RDS)
                 # -------------------------
                 - Namespace: aws:elasticbeanstalk:application:environment
                   OptionName: NODE_ENV

--- a/CF-templates/roles.yaml
+++ b/CF-templates/roles.yaml
@@ -1,0 +1,82 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'CloudFormation template to create IAM roles and an EC2 Instance Profile for AWS Elastic Beanstalk environments.'
+
+Resources:
+    # --------------------------------------------------------------------------
+    # 1. Elastic Beanstalk Service Role
+    # --------------------------------------------------------------------------
+    # This role is assumed by the Elastic Beanstalk service itself to provision
+    # and manage AWS resources (like Auto Scaling Groups, Load Balancers, etc.)
+    # on your behalf.
+    EBServiceRole:
+        Type: 'AWS::IAM::Role'
+        Properties:
+            RoleName: !Sub '${AWS::StackName}-ServiceRole'
+            AssumeRolePolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                    - Effect: Allow
+                      Principal:
+                          Service:
+                              - 'elasticbeanstalk.amazonaws.com'
+                      Action: 'sts:AssumeRole'
+                      Condition:
+                          StringEquals:
+                              'sts:ExternalId': 'elasticbeanstalk'
+            ManagedPolicyArns:
+                - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth'
+                - 'arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService'
+
+    # --------------------------------------------------------------------------
+    # 2. EC2 Instance Role (for the nodes cluster)
+    # --------------------------------------------------------------------------
+    # This role is assumed by the actual EC2 instances (t4g.small) created by
+    # Elastic Beanstalk. It grants the Node.js application permissions to interact
+    # with minimal AWS services (like CloudWatch Logs or S3 for deployments).
+    EBInstanceRole:
+        Type: 'AWS::IAM::Role'
+        Properties:
+            RoleName: !Sub '${AWS::StackName}-EC2Role'
+            AssumeRolePolicyDocument:
+                Version: '2012-10-17'
+                Statement:
+                    - Effect: Allow
+                      Principal:
+                          Service:
+                              - 'ec2.amazonaws.com'
+                      Action: 'sts:AssumeRole'
+            ManagedPolicyArns:
+                - 'arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier'
+            Policies:
+                - PolicyName: 'CloudWatchLogsPolicy'
+                  PolicyDocument:
+                      Version: '2012-10-17'
+                      Statement:
+                          - Effect: Allow
+                            Action:
+                                - 'logs:CreateLogGroup'
+                                - 'logs:CreateLogStream'
+                                - 'logs:PutLogEvents'
+                                - 'logs:DescribeLogStreams'
+                            Resource: '*'
+
+    # --------------------------------------------------------------------------
+    # 3. EC2 Instance Profile
+    # --------------------------------------------------------------------------
+    # An Instance Profile is an AWS container for an IAM role that allows you
+    # to attach the role to an EC2 instance. This is what you select in the
+    # Elastic Beanstalk configuration UI under "IAM instance profile".
+    EBInstanceProfile:
+        Type: 'AWS::IAM::InstanceProfile'
+        Properties:
+            InstanceProfileName: !Sub '${AWS::StackName}-InstanceProfile'
+            Roles:
+                - !Ref EBInstanceRole
+
+Outputs:
+    EBServiceRoleArn:
+        Description: 'The ARN of the Elastic Beanstalk Service Role'
+        Value: !GetAtt EBServiceRole.Arn
+    EBInstanceProfileName:
+        Description: 'The name of the EC2 Instance Profile to use in your Elastic Beanstalk environment configuration'
+        Value: !Ref EBInstanceProfile

--- a/CF-templates/roles.yaml
+++ b/CF-templates/roles.yaml
@@ -77,6 +77,11 @@ Outputs:
     EBServiceRoleArn:
         Description: 'The ARN of the Elastic Beanstalk Service Role'
         Value: !GetAtt EBServiceRole.Arn
+        Export:
+            Name: SoitinStock-ServiceRoleArn
+
     EBInstanceProfileName:
         Description: 'The name of the EC2 Instance Profile to use in your Elastic Beanstalk environment configuration'
         Value: !Ref EBInstanceProfile
+        Export:
+            Name: SoitinStock-InstanceProfileName


### PR DESCRIPTION
These templates are ready in this merge, and work as intended. They build the base infrastructure for our app. 