### PR TITLE
Fixed the imageplaceholder being too big on smaller screens in the modal

### DIFF
--- a/client/src/app/modal/modal.css
+++ b/client/src/app/modal/modal.css
@@ -266,4 +266,9 @@ button:hover {
     width: 100px;
     height: 100px;
   }
+
+  .image-placeholder {
+    width: 100px;
+    height: 100px;
+  }
 }


### PR DESCRIPTION
Fixed the imageplaceholder being 200px wide and tall on smaller screens in the modal.